### PR TITLE
Report errors on comments with no starting space

### DIFF
--- a/D3R-PHP.xml
+++ b/D3R-PHP.xml
@@ -2,11 +2,9 @@
 <ruleset name="D3R">
     <description>The D3R Coding Standard</description>
     <rule ref="PSR2">
-        <exclude name="PSR1.Classes.ClassDeclaration"/>
-        <exclude name="PSR2.Methods.MethodDeclaration" />
-        <exclude name="PSR2.Classes.PropertyDeclaration"/>
-        <exclude name="Squiz.Classes.ValidClassName"/>
-        <exclude name="Generic.Files.LineLength" />
+        <exclude name="PSR1.Classes.ClassDeclaration" />
+        <exclude name="PSR2.Classes.PropertyDeclaration" />
+        <exclude name="Squiz.Classes.ValidClassName" />
     </rule>
     <rule ref="PSR1.Files.SideEffects">
        <exclude-pattern>*/tools/*</exclude-pattern>

--- a/D3R-PHP.xml
+++ b/D3R-PHP.xml
@@ -6,4 +6,9 @@
 	<exclude name="PSR2.Classes.PropertyDeclaration" />
 	<exclude name="Squiz.Classes.ValidClassName" />
  </rule>
+ <rule ref="Squiz.Commenting.InlineComment">
+        <exclude name="Squiz.Commenting.InlineComment.NotCapital" />
+        <exclude name="Squiz.Commenting.InlineComment.SpacingAfter" />
+        <exclude name="Squiz.Commenting.InlineComment.InvalidEndChar" />
+  </rule>
 </ruleset>

--- a/D3R-PHP.xml
+++ b/D3R-PHP.xml
@@ -1,17 +1,24 @@
 <?xml version="1.0"?>
 <ruleset name="D3R">
- <description>The D3R Coding Standard</description>
- <rule ref="PSR2">
-	<exclude name="PSR1.Classes.ClassDeclaration" />
-	<exclude name="PSR2.Classes.PropertyDeclaration" />
-	<exclude name="Squiz.Classes.ValidClassName" />
- </rule>
- <rule ref="Squiz.Commenting.InlineComment">
+    <description>The D3R Coding Standard</description>
+    <rule ref="PSR2">
+        <exclude name="PSR1.Classes.ClassDeclaration"/>
+        <exclude name="PSR2.Methods.MethodDeclaration" />
+        <exclude name="PSR2.Classes.PropertyDeclaration"/>
+        <exclude name="Squiz.Classes.ValidClassName"/>
+        <exclude name="Generic.Files.LineLength" />
+    </rule>
+    <rule ref="PSR1.Files.SideEffects">
+       <exclude-pattern>*/tools/*</exclude-pattern>
+    </rule>
+
+    <rule ref="Squiz.Commenting.InlineComment">
         <exclude name="Squiz.Commenting.InlineComment.NotCapital" />
         <exclude name="Squiz.Commenting.InlineComment.SpacingAfter" />
         <exclude name="Squiz.Commenting.InlineComment.InvalidEndChar" />
         <exclude name="Squiz.Commenting.InlineComment.DocBlock" />
         <exclude name="Squiz.Commenting.InlineComment.WrongStyle" />
         <exclude name="Squiz.Commenting.InlineComment.InvalidEndChar" />
-  </rule>
+        <exclude name="Squiz.Commenting.InlineComment.SpacingBefore" />
+    </rule>
 </ruleset>

--- a/D3R-PHP.xml
+++ b/D3R-PHP.xml
@@ -6,10 +6,6 @@
         <exclude name="PSR2.Classes.PropertyDeclaration" />
         <exclude name="Squiz.Classes.ValidClassName" />
     </rule>
-    <rule ref="PSR1.Files.SideEffects">
-       <exclude-pattern>*/tools/*</exclude-pattern>
-    </rule>
-
     <rule ref="Squiz.Commenting.InlineComment">
         <exclude name="Squiz.Commenting.InlineComment.NotCapital" />
         <exclude name="Squiz.Commenting.InlineComment.SpacingAfter" />

--- a/D3R-PHP.xml
+++ b/D3R-PHP.xml
@@ -10,5 +10,8 @@
         <exclude name="Squiz.Commenting.InlineComment.NotCapital" />
         <exclude name="Squiz.Commenting.InlineComment.SpacingAfter" />
         <exclude name="Squiz.Commenting.InlineComment.InvalidEndChar" />
+        <exclude name="Squiz.Commenting.InlineComment.DocBlock" />
+        <exclude name="Squiz.Commenting.InlineComment.WrongStyle" />
+        <exclude name="Squiz.Commenting.InlineComment.InvalidEndChar" />
   </rule>
 </ruleset>


### PR DESCRIPTION
`//This Comment Will report as error`

`// This comment is rad and great`

https://github.com/squizlabs/PHP_CodeSniffer/blob/master/CodeSniffer/Standards/Squiz/Sniffs/Commenting/InlineCommentSniff.php

Excludes everything else