### PR TITLE
Remove check for Class CONST visibility

### DIFF
--- a/D3R-PSR12.xml
+++ b/D3R-PSR12.xml
@@ -7,6 +7,7 @@
         <exclude name="PSR2.Classes.PropertyDeclaration"/>
         <exclude name="Squiz.Classes.ValidClassName"/>
         <exclude name="Generic.Files.LineLength" />
+        <exclude name="PSR12.Properties.ConstantVisibility.NotFound" />
     </rule>
     <rule ref="PSR1.Files.SideEffects">
        <exclude-pattern>*/tools/*</exclude-pattern>


### PR DESCRIPTION
This is causing issues on PHPCI `PHPCS: Visibility must be declared on all constants if your project supports PHP 7.1 or later`.

We can't enforce this on 7.0 compatible builds at the moment, its a little weird that this is stated in the spec as `Visibility MUST be declared on all constants if your project PHP minimum version supports constant visibilities (PHP 7.1 or later).` and is getting flagged as a warning when we have our platform config as `7.0.x`.

Either way, the PHPCI server can't enforce this check because its 7.0 and setting the visibility would cause syntax errors. Shall we skip this test until we are fully 7.3+ everywhere?

Before - https://phpci.d3r.com/build/view/59343
After - https://phpci.d3r.com/build/view/59351