### PR TITLE
Exclude the spacing around control structures rule for PSR-12 compatibility

### DIFF
--- a/D3R-PHP.xml
+++ b/D3R-PHP.xml
@@ -7,6 +7,7 @@
         <exclude name="PSR2.Classes.PropertyDeclaration"/>
         <exclude name="Squiz.Classes.ValidClassName"/>
         <exclude name="Generic.Files.LineLength" />
+        <exclude name="PSR2.ControlStructures.ControlStructureSpacing"></exclude>
     </rule>
     <rule ref="PSR1.Files.SideEffects">
        <exclude-pattern>*/tools/*</exclude-pattern>


### PR DESCRIPTION
PSR-12 wants
```php
if (
    $a === $b
    && $c === $d
) {
    // blah
}
```

but PSR-2 wants no space after the opening bracket:
```php
if ($a === $b
    && $c === $d
) {
    // blah
}
```

Either way, one of them will give us an error.

Other suggestions for how to resolve this conflict are very welcome.