### PR TITLE
Document pull request standards

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,0 +1,8 @@
+name: PR Maintainer
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  pr-maintainer:
+    uses: "D3R/github-workflows/.github/workflows/pr.yaml@GHA-36-pr-checkboxes"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,8 +1,0 @@
-name: PR Maintainer
-on:
-  pull_request:
-    types: [opened, edited, synchronize, reopened]
-
-jobs:
-  pr-maintainer:
-    uses: "D3R/github-workflows/.github/workflows/pr.yaml@GHA-36-pr-checkboxes"

--- a/docs/pull-requests.md
+++ b/docs/pull-requests.md
@@ -1,0 +1,1 @@
+# Pull Requests

--- a/docs/pull-requests.md
+++ b/docs/pull-requests.md
@@ -1,6 +1,6 @@
 # Pull Requests
 
-## Pull Request Description
+## Description
 ### Task Lists
 Task lists are lists of checkboxes, written in Markdown. We typically use them as a lightweight mechanism to list the things that need to be done before a PR is ready for review, or ready to merge. If a task list exists in a PR description, the PR cannot be merged until every task has been marked as completed or not applicable.
 

--- a/docs/pull-requests.md
+++ b/docs/pull-requests.md
@@ -1,1 +1,13 @@
 # Pull Requests
+
+## Pull Request Description
+### Task Lists
+Task lists are lists of checkboxes, written in Markdown. We typically use them as a lightweight mechanism to list the things that need to be done before a PR is ready for review, or ready to merge. If a task list exists in a PR description, the PR cannot be merged until every task has been marked as completed or not applicable.
+
+- [ ] Incomplete task
+- [x] Completed task
+- [ ] ~~Task that's only relevant to frontend PRs~~ N/A _backend only change_
+
+See [Github's documentation](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/about-task-lists#about-task-lists) for further information on how to use task lists.
+
+Documentation on the task list checker can be found [here](https://github.com/Shopify/task-list-checker/blob/main/README.md#in-a-pull-request).


### PR DESCRIPTION
Initially required for https://d3rjira.atlassian.net/browse/GHA-36, so we have somewhere to point to when the check fails.