### PR TITLE
GHA-2: Only scan php files by default

### DIFF
--- a/D3R-PSR12.xml
+++ b/D3R-PSR12.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <ruleset name="D3R">
     <description>The D3R PSR-12 Coding Standard</description>
+    <arg name="extensions" value="php" />
     <rule ref="PSR12">
         <exclude name="PSR1.Classes.ClassDeclaration"/>
         <exclude name="PSR2.Methods.MethodDeclaration" />


### PR DESCRIPTION
With [GHA-2](https://d3rjira.atlassian.net/browse/GHA-2), we'll soon be running phpcs on all D3R repositories containing PHP code, with `D3R-PSR12.xml` as the standard. However, many html files containing PHP don't fully conform to the existing standard. As html templates are discouraged, in favour of Twig, it doesn't seem like a good idea to encourage developers to spend time tidying them up.

We could add an `--extensions` flag to the phcs command run by the GitHub Actions workflow, but making the change here means the behaviour of running phpcs on a local machine will be more aligned with the workflow.

[GHA-2]: https://d3rjira.atlassian.net/browse/GHA-2?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ