### PR TITLE
Promote D3R-PSR12.xml to D3R standard

### DIFF
--- a/D3R-DEV-PHP.xml
+++ b/D3R-DEV-PHP.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0"?>
 <ruleset name="D3R-DEV">
+    <!-- IMPORTANT: This standards file is deprecated, in favour of D3R-PHP.xml -->
     <description>The D3R Development Coding Standard</description>
-    <rule ref="PSR12">
-        <exclude name="PSR1.Classes.ClassDeclaration"/>
-        <exclude name="PSR2.Classes.PropertyDeclaration"/>
-        <exclude name="Squiz.Classes.ValidClassName"/>
-    </rule>
+    <rule ref="./D3R-PHP.xml" />
 </ruleset>

--- a/D3R-PHP.xml
+++ b/D3R-PHP.xml
@@ -13,6 +13,9 @@
        <exclude-pattern>*/tools/*</exclude-pattern>
        <exclude-pattern>*/scripts/*</exclude-pattern>
     </rule>
+    <rule ref="Generic.PHP.DeprecatedFunctions">
+        <type>warning</type>
+    </rule>
     <rule ref="Squiz.Commenting.InlineComment">
         <exclude name="Squiz.Commenting.InlineComment.NotCapital" />
         <exclude name="Squiz.Commenting.InlineComment.SpacingAfter" />

--- a/D3R-PHP.xml
+++ b/D3R-PHP.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0"?>
 <ruleset name="D3R">
     <description>The D3R Coding Standard</description>
-    <rule ref="PSR2">
+    <rule ref="PSR12">
         <exclude name="PSR1.Classes.ClassDeclaration"/>
         <exclude name="PSR2.Methods.MethodDeclaration" />
         <exclude name="PSR2.Classes.PropertyDeclaration"/>
         <exclude name="Squiz.Classes.ValidClassName"/>
         <exclude name="Generic.Files.LineLength" />
-        <exclude name="PSR2.ControlStructures.ControlStructureSpacing"></exclude>
+        <exclude name="PSR12.Properties.ConstantVisibility.NotFound" />
     </rule>
     <rule ref="PSR1.Files.SideEffects">
        <exclude-pattern>*/tools/*</exclude-pattern>

--- a/D3R-PHP.xml
+++ b/D3R-PHP.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <ruleset name="D3R">
     <description>The D3R Coding Standard</description>
+    <arg name="extensions" value="php" />
     <rule ref="PSR12">
         <exclude name="PSR1.Classes.ClassDeclaration"/>
         <exclude name="PSR2.Methods.MethodDeclaration" />

--- a/D3R-PHP.xml
+++ b/D3R-PHP.xml
@@ -7,11 +7,13 @@
         <exclude name="PSR2.Classes.PropertyDeclaration"/>
         <exclude name="Squiz.Classes.ValidClassName"/>
         <exclude name="Generic.Files.LineLength" />
-        <exclude name="PSR12.Properties.ConstantVisibility.NotFound" />
     </rule>
     <rule ref="PSR1.Files.SideEffects">
-       <exclude-pattern>*/tools/*</exclude-pattern>
-       <exclude-pattern>*/scripts/*</exclude-pattern>
+        <exclude-pattern>*/tools/*</exclude-pattern>
+        <exclude-pattern>*/scripts/*</exclude-pattern>
+    </rule>
+    <rule ref="PSR12.Properties.ConstantVisibility">
+        <type>warning</type>
     </rule>
     <rule ref="Generic.PHP.DeprecatedFunctions">
         <type>warning</type>

--- a/D3R-PSR12.xml
+++ b/D3R-PSR12.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
 <ruleset name="D3R">
-    <description>The D3R PSR-12 Coding Standard</description>
+    <!-- IMPORTANT: This standards file is deprecated, in favour of D3R-PHP.xml -->
+    <description>The D3R Coding Standard</description>
     <rule ref="./D3R-PHP.xml" />
 </ruleset>

--- a/D3R-PSR12.xml
+++ b/D3R-PSR12.xml
@@ -1,25 +1,5 @@
 <?xml version="1.0"?>
 <ruleset name="D3R">
     <description>The D3R PSR-12 Coding Standard</description>
-    <rule ref="PSR12">
-        <exclude name="PSR1.Classes.ClassDeclaration"/>
-        <exclude name="PSR2.Methods.MethodDeclaration" />
-        <exclude name="PSR2.Classes.PropertyDeclaration"/>
-        <exclude name="Squiz.Classes.ValidClassName"/>
-        <exclude name="Generic.Files.LineLength" />
-        <exclude name="PSR12.Properties.ConstantVisibility.NotFound" />
-    </rule>
-    <rule ref="PSR1.Files.SideEffects">
-       <exclude-pattern>*/tools/*</exclude-pattern>
-       <exclude-pattern>*/scripts/*</exclude-pattern>
-    </rule>
-    <rule ref="Squiz.Commenting.InlineComment">
-        <exclude name="Squiz.Commenting.InlineComment.NotCapital" />
-        <exclude name="Squiz.Commenting.InlineComment.SpacingAfter" />
-        <exclude name="Squiz.Commenting.InlineComment.InvalidEndChar" />
-        <exclude name="Squiz.Commenting.InlineComment.DocBlock" />
-        <exclude name="Squiz.Commenting.InlineComment.WrongStyle" />
-        <exclude name="Squiz.Commenting.InlineComment.InvalidEndChar" />
-        <exclude name="Squiz.Commenting.InlineComment.SpacingBefore" />
-    </rule>
+    <rule ref="./D3R-PHP.xml" />
 </ruleset>


### PR DESCRIPTION
This PR promotes the ruleset in `D3R-PSR12.xml` to be the D3R standard, by moving the rules into `D3R-PHP.xml` and having `D3R-PSR12.xml` use `D3R-PHP.xml`.

The intention is to get all repositories using the same base standard. PSR-12 has been superseded by the [PER Coding Style](https://www.php-fig.org/per/coding-style/), which covers newer PHP language features and is something I believe we may want to consider using in the future. Additionally, I believe we should gradually introduce additional rules not covered by these standards. Therefore, `D3R-PHP.xml` standard is more appropriately named for future standards improvements.

For the [many repositories already using `D3R-PSR12.xml`](https://github.com/search?q=org%3AD3R+%22D3R-PSR12.xml%22++NOT+is%3Aarchived&type=code), there will be no change. [Most usage](https://github.com/search?q=org%3AD3R+%22D3R-PSR12.xml%22++NOT+is%3Aarchived+NOT+path%3A.php-censor.yml&type=code) comes from `.php-censor.yml`, which will be going away and replaced by the PHP GitHub Actions workflow which will use this same standard. Other usage is in local `phpcs.xml.dist` files, many of which will no longer be necessary once https://github.com/D3R/github-workflows/pull/70 is merged. We can consider deleting `D3R-PSR12.xml` in the future, when it is no longer used, but there is no rush to do so.

[Some repositories](https://github.com/search?q=org%3AD3R+%22D3R-PHP.xml%22++NOT+is%3Aarchived&type=code) are using `D3R-PHP.xml`, based on the [PSR-2 Coding Style Guide](https://www.php-fig.org/psr/psr-2/), so this change may affect them. That standard was deprecated in August 2019, in part because it doesn't cover newer language features, so it's reasonable to expect those repositories to migrate to the newer standard. I've seen many repositories migrate to `D3R-PSR12.xml` with very little impact and the changes tend to be related to use of whitespace. The implementation of https://github.com/D3R/github-workflows/pull/70 will mean that developers working on these repositories will only be forced to fix existing errors in files they change. We're already considering a Lunch & Learn session, or something similar to help developers understand how best to deal with existing phpcs errors, so I believe the impact will be small and manageable.