### PR TITLE
Deprecate D3R-DEV-PHP.xml

### DIFF
--- a/D3R-DEV-PHP.xml
+++ b/D3R-DEV-PHP.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0"?>
 <ruleset name="D3R-DEV">
+    <!-- IMPORTANT: This standards file is deprecated, in favour of D3R-PHP.xml -->
     <description>The D3R Development Coding Standard</description>
-    <rule ref="PSR12">
-        <exclude name="PSR1.Classes.ClassDeclaration"/>
-        <exclude name="PSR2.Classes.PropertyDeclaration"/>
-        <exclude name="Squiz.Classes.ValidClassName"/>
-    </rule>
+    <rule ref="./D3R-PHP.xml" />
 </ruleset>


### PR DESCRIPTION
This PR deprecates the `D3R-DEV-PHP.xml` standard and makes it work the same as `D3R-PHP.xml` (which in #13 was aligned with `D3R-PSR12.xml`).

There is [very limited use in CI environments](https://github.com/search?q=org%3AD3R+%22D3R-DEV-PHP%22++NOT+is%3Aarchived&type=code) and it is likely that only a small percentage of developers are using it locally. As the standard was intended to be a superset of `D3R-PSR12.xml`, no impact is expected.

After the release of https://github.com/D3R/github-workflows/pull/70, we can consider enhancing phpcs coding standards in a way that minimises disruption to developers. Specifically, we can introduce new rules as warnings, so annotations appear in PRs without preventing the PR from being merged. Therefore, there doesn't seem to be a clear need for maintaining a stronger standard for local use.