### PR TITLE
Enable Generic.PHP.DeprecatedFunctions

### DIFF
--- a/D3R-PHP.xml
+++ b/D3R-PHP.xml
@@ -13,6 +13,9 @@
        <exclude-pattern>*/tools/*</exclude-pattern>
        <exclude-pattern>*/scripts/*</exclude-pattern>
     </rule>
+    <rule ref="Generic.PHP.DeprecatedFunctions">
+        <type>warning</type>
+    </rule>
     <rule ref="Squiz.Commenting.InlineComment">
         <exclude name="Squiz.Commenting.InlineComment.NotCapital" />
         <exclude name="Squiz.Commenting.InlineComment.SpacingAfter" />


### PR DESCRIPTION
Each new PHP version tends to deprecate built-in php functions. These deprecations cause noise in error logs and eventually a version of PHP is released that forces developers to stop using them. The intention of this PR is to increase visibility of these deprecations, in order to discourage use in new code and spread out the work of fixing existing code over the course of several months or years, in advance of a PHP upgrade.

This PR proposes that we enable the phpcs `Generic.PHP.DeprecatedFunctions` rule as a warning. With https://github.com/D3R/github-workflows/pull/70, developers will see PR annotations when a deprecated function is used, but it will not stop PRs from being merged. It will also only produce warnings for functions deprecated in the version of PHP that ran phpcs.

Example output using PHP 8.2 with `d3r/core`.

```
vagrant@vagrant-jargon7:/code/github.com/D3R/core$ ./vendor/bin/phpcs -d memory_limit=2G --parallel=4 --basepath="$PWD" --ignore='vendor,build,tmp' --standard='vendor/d3r/standards/D3R-PSR12.xml' --extensions=php .; echo $?

FILE: library/d3r_core/D3R/Service/Apple/Push/Payload.php
----------------------------------------------------------------------
FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
----------------------------------------------------------------------
 86 | WARNING | Function utf8_decode() has been deprecated
----------------------------------------------------------------------


FILE: library/d3r_core/D3R/Client/Rest/Request/Oauth.php
----------------------------------------------------------------------
FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
----------------------------------------------------------------------
 93 | WARNING | Function utf8_encode() has been deprecated
----------------------------------------------------------------------


FILE: library/d3r_core/D3R/Oauth/Client.php
----------------------------------------------------------------------
FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
----------------------------------------------------------------------
 74 | WARNING | Function utf8_encode() has been deprecated
----------------------------------------------------------------------

Time: 6.38 secs; Memory: 10MB
```