### PR TITLE
Promote PSR12.Properties.ConstantVisibility to warning

### DIFF
--- a/D3R-PHP.xml
+++ b/D3R-PHP.xml
@@ -7,11 +7,13 @@
         <exclude name="PSR2.Classes.PropertyDeclaration"/>
         <exclude name="Squiz.Classes.ValidClassName"/>
         <exclude name="Generic.Files.LineLength" />
-        <exclude name="PSR12.Properties.ConstantVisibility.NotFound" />
     </rule>
     <rule ref="PSR1.Files.SideEffects">
        <exclude-pattern>*/tools/*</exclude-pattern>
        <exclude-pattern>*/scripts/*</exclude-pattern>
+    </rule>
+    <rule ref="PSR12.Properties.ConstantVisibility">
+        <type>warning</type>
     </rule>
     <rule ref="Squiz.Commenting.InlineComment">
         <exclude name="Squiz.Commenting.InlineComment.NotCapital" />


### PR DESCRIPTION
This PR promotes the `PSR12.Properties.ConstantVisibility` rule output warnings when constant visibility is not specified. It's been possible to specify this since PHP 7.1.0 and many developers already do. We are long past the point where we need to maintain support for PHP 7.0. Specifying visibility is good practice and encourages developers to consider whether it is actually appropriate for a constant to be public.

With https://github.com/D3R/github-workflows/pull/70, developers will see PR annotations when this rule is not satisfied, but it will not stop PRs from being merged.

[Many repositories](https://github.com/search?q=org%3AD3R%20language%3APHP%20NOT%20is%3Aarchived%20%2F%5Cs*const%20%2F&type=code) will see warnings for this new rule, but only in a handful of files. Soho is the most impacted. Notably, several newer codebases include some code that doesn't comply with this proposed rule.

